### PR TITLE
Fix strict compatibility

### DIFF
--- a/src/svg.easing.js
+++ b/src/svg.easing.js
@@ -171,6 +171,6 @@
 
     }
 
-    for (key in easing)
+    for (var key in easing)
         SVG.easing[key] = easing[key]
 })()


### PR DESCRIPTION
Missing 'var' results in an error whilst running in strict mode, e.g.:  `ReferenceError : assignment to undeclared variable key`.